### PR TITLE
Support ES7.0, use primary_term and seq_no for job doc versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
 
 buildscript {
     ext {
-        es_version = System.getProperty("es.version", "6.7.1")
+        es_version = System.getProperty("es.version", "7.0.1")
     }
 
     repositories {
@@ -64,10 +64,7 @@ esplugin {
 integTestRunner {
     // add "-Dtests.security.manager=false" to VM options if you want to run integ tests in IntelliJ
     systemProperty 'tests.security.manager', 'false'
-    // TODO: FIXME
-    ifNoTests 'ignore'
 }
-
 
 allprojects {
     group = 'com.amazon.opendistroforelasticsearch'

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ integTestRunner {
     systemProperty 'tests.security.manager', 'false'
 }
 
+integTestCluster {
+    distribution = "oss-zip"
+}
+
 allprojects {
     group = 'com.amazon.opendistroforelasticsearch'
     version = "${opendistroVersion}.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@
 #   permissions and limitations under the License.
 #
 
-version = 0.9.0
+version = 1.0.0

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -36,5 +36,6 @@ testingConventions.enabled = false;
 
 
 integTestCluster {
-    module rootProject
+    distribution = "oss-zip"
+    plugin(rootProject.getPath())
 }

--- a/sample-extension-plugin/build.gradle
+++ b/sample-extension-plugin/build.gradle
@@ -32,8 +32,6 @@ dependencies {
     compileOnly project(path: ":${rootProject.name}-spi", configuration: 'shadow')
 }
 
-unitTest.enabled = false;
-integTestRunner.enabled = false;
 testingConventions.enabled = false;
 
 

--- a/sample-extension-plugin/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sampleextension/SampleJobRunner.java
+++ b/sample-extension-plugin/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sampleextension/SampleJobRunner.java
@@ -83,13 +83,13 @@ public class SampleJobRunner implements ScheduledJobRunner {
 
         SampleJobParameter parameter = (SampleJobParameter)jobParameter;
         StringBuilder msg = new StringBuilder();
-        msg.append("Watching index " + parameter.getIndexToWatch() + "\n");
+        msg.append("Watching index ").append(parameter.getIndexToWatch()).append("\n");
 
 
         List<ShardRouting> shardRoutingList = this.clusterService.state().routingTable().allShards(parameter.getIndexToWatch());
         for(ShardRouting shardRouting : shardRoutingList) {
-            msg.append(shardRouting.shardId().getId() + "\t" + shardRouting.currentNodeId() +
-                    "\t" + (shardRouting.active() ? "active" : "inactive") + "\n");
+            msg.append(shardRouting.shardId().getId()).append("\t").append(shardRouting.currentNodeId()).append("\t")
+                    .append(shardRouting.active() ? "active" : "inactive").append("\n");
         }
         log.info(msg.toString());
     }

--- a/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/JobDocVersion.java
+++ b/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/JobDocVersion.java
@@ -1,0 +1,74 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.jobscheduler.spi;
+
+/**
+ * Structure to represent scheduled job document version. JobScheduler use this to determine this job
+ */
+public class JobDocVersion implements Comparable<JobDocVersion> {
+    private final long primaryTerm;
+    private final long seqNo;
+    private final long version;
+
+    public JobDocVersion(long primaryTerm, long seqNo, long version) {
+        this.primaryTerm = primaryTerm;
+        this.seqNo = seqNo;
+        this.version = version;
+    }
+
+    public long getPrimaryTerm() {
+        return primaryTerm;
+    }
+
+    public long getSeqNo() {
+        return seqNo;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    /**
+     * Compare two doc versions. Refer to https://github.com/elastic/elasticsearch/issues/10708
+     *
+     * @param v the doc version to compare.
+     * @return -1 if this < v, 0 if this == v, otherwise 1;
+     */
+    @Override
+    public int compareTo(JobDocVersion v) {
+        if (v == null) {
+            return 1;
+        }
+        if (this.seqNo < v.seqNo) {
+            return -1;
+        }
+        if (this.seqNo > v.seqNo) {
+            return 1;
+        }
+        if(this.primaryTerm < v.primaryTerm) {
+            return -1;
+        }
+        if(this.primaryTerm > v.primaryTerm) {
+            return 1;
+        }
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("{_version: %s, _primary_term: %s, _seq_no: %s}", this.version, this.primaryTerm, this.seqNo);
+    }
+}

--- a/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/JobExecutionContext.java
+++ b/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/JobExecutionContext.java
@@ -19,6 +19,7 @@ import java.time.Instant;
 
 public class JobExecutionContext {
     private Instant expectedExecutionTime;
+    private JobDocVersion jobVersion;
 
     public Instant getExpectedExecutionTime() {
         return this.expectedExecutionTime;
@@ -26,5 +27,13 @@ public class JobExecutionContext {
 
     public void setExpectedExecutionTime(Instant expectedExecutionTime) {
         this.expectedExecutionTime = expectedExecutionTime;
+    }
+
+    public JobDocVersion getJobVersion() {
+        return this.jobVersion;
+    }
+
+    public void setJobVersion(JobDocVersion jobVersion) {
+        this.jobVersion = jobVersion;
     }
 }

--- a/spi/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/JobDocVersionTest.java
+++ b/spi/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/JobDocVersionTest.java
@@ -1,0 +1,40 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.jobscheduler.spi.schedule;
+
+import com.amazon.opendistroforelasticsearch.jobscheduler.spi.JobDocVersion;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JobDocVersionTest {
+
+    @Test
+    public void testCompareTo() {
+        // constructor parameters: primary_term, seqNo, version
+        JobDocVersion version1 = new JobDocVersion(1L, 1l, 1L);
+        Assert.assertTrue(version1.compareTo(null) > 0);
+
+        JobDocVersion version2 = new JobDocVersion(1L, 2L, 1L);
+        Assert.assertTrue(version1.compareTo(version2) < 0);
+
+        JobDocVersion version3 = new JobDocVersion(2L, 1L, 1L);
+        Assert.assertTrue(version1.compareTo(version3) < 0);
+        Assert.assertTrue(version2.compareTo(version3) > 0);
+
+        JobDocVersion version4 = new JobDocVersion(1L, 1L, 1L);
+        Assert.assertTrue(version1.compareTo(version4) == 0);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
@@ -218,9 +218,8 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
             this.sweptJobs.put(shardId, jobVersionMap);
         }
         jobVersionMap.compute(docId, (id, currentVersion) -> {
-            JobDocVersion newJobVersion = new JobDocVersion(version.getPrimaryTerm(), version.getSeqNo(), version.getVersion());
-            if (newJobVersion.compareTo(currentVersion) <= 0) {
-                log.info("Skipping job {}, new version {} <= current version {}", docId, newJobVersion, currentVersion);
+            if (version.compareTo(currentVersion) <= 0) {
+                log.info("Skipping job {}, new version {} <= current version {}", docId, version, currentVersion);
                 return currentVersion;
             }
 
@@ -239,9 +238,9 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
                     }
                     ScheduledJobRunner jobRunner = this.indexToProviders.get(shardId.getIndexName()).getJobRunner();
                     if (jobParameter.isEnabled()) {
-                        this.scheduler.schedule(shardId.getIndexName(), docId, jobParameter, jobRunner, newJobVersion);
+                        this.scheduler.schedule(shardId.getIndexName(), docId, jobParameter, jobRunner, version);
                     }
-                    return newJobVersion;
+                    return version;
                 } catch (Exception e) {
                     log.warn("Unable to parse job, error message: {} , message source: {}", e.getMessage(),
                             Strings.cleanTruncate(jobSource.utf8ToString(), 1000));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
@@ -188,8 +188,7 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
 
         ShardNodes shardNodes = new ShardNodes(localNodeId, shardNodeIds);
         if (shardNodes.isOwningNode(index.id())) {
-            JobDocVersion jobDocVersion = new JobDocVersion(result.getTerm(), result.getSeqNo(), result.getVersion());
-            this.sweep(shardId, index.id(), index.source(), jobDocVersion);
+            this.sweep(shardId, index.id(), index.source(), new JobDocVersion(result.getTerm(), result.getSeqNo(),result.getVersion()));
         }
     }
 
@@ -368,8 +367,8 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
             for (SearchHit hit: response.getHits()) {
                 String jobId = hit.getId();
                 if(shardNodes.isOwningNode(jobId)) {
-                    JobDocVersion jobDocVersion = new JobDocVersion(hit.getPrimaryTerm(), hit.getSeqNo(), hit.getVersion());
-                    this.sweep(shardId, jobId, hit.getSourceRef(), jobDocVersion);
+                    this.sweep(shardId, jobId, hit.getSourceRef(), new JobDocVersion(hit.getPrimaryTerm(), hit.getSeqNo(),
+                            hit.getVersion()));
                 }
             }
             if (response.getHits() == null || response.getHits().getHits().length < 1) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeperTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeperTests.java
@@ -18,6 +18,7 @@ package com.amazon.opendistroforelasticsearch.jobscheduler.sweeper;
 import com.amazon.opendistroforelasticsearch.jobscheduler.JobSchedulerSettings;
 import com.amazon.opendistroforelasticsearch.jobscheduler.ScheduledJobProvider;
 import com.amazon.opendistroforelasticsearch.jobscheduler.scheduler.JobScheduler;
+import com.amazon.opendistroforelasticsearch.jobscheduler.spi.JobDocVersion;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.ScheduledJobParameter;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.ScheduledJobParser;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.ScheduledJobRunner;
@@ -139,7 +140,8 @@ public class JobSweeperTests extends ESAllocationTestCase {
 
         this.sweeper.initBackgroundSweep();
         Mockito.verify(cancellable).cancel();
-        Mockito.verify(this.threadPool, Mockito.times(2)).scheduleWithFixedDelay(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(this.threadPool, Mockito.times(2))
+                .scheduleWithFixedDelay(Mockito.any(), Mockito.any(), Mockito.anyString());
     }
 
     @Test
@@ -193,12 +195,14 @@ public class JobSweeperTests extends ESAllocationTestCase {
 
         Mockito.when(this.clusterService.state()).thenReturn(clusterState);
         JobSweeper testSweeper = Mockito.spy(this.sweeper);
-        Mockito.doNothing().when(testSweeper).sweep(Mockito.any(), Mockito.anyString(), Mockito.anyLong(), Mockito.any());
+        Mockito.doNothing().when(testSweeper).sweep(Mockito.any(), Mockito.anyString(), Mockito.anyLong(), Mockito.any(),
+                Mockito.anyLong(), Mockito.anyLong());
         for (int i = 0; i<clusterState.getNodes().getSize(); i++) {
             testSweeper.postIndex(shardId, index, indexResult);
         }
 
-        Mockito.verify(testSweeper).sweep(Mockito.any(), Mockito.anyString(), Mockito.anyLong(), Mockito.any());
+        Mockito.verify(testSweeper).sweep(Mockito.any(), Mockito.anyString(), Mockito.anyLong(), Mockito.any(),
+                Mockito.anyLong(), Mockito.anyLong());
     }
 
     @Test
@@ -242,15 +246,17 @@ public class JobSweeperTests extends ESAllocationTestCase {
     public void testSweep() throws IOException {
         ShardId shardId = new ShardId(new Index("index-name", IndexMetaData.INDEX_UUID_NA_VALUE), 1);
 
-        this.sweeper.sweep(shardId, "id", 2L, this.getTestJsonSource());
-        Mockito.verify(this.scheduler, Mockito.times(0)).schedule(Mockito.anyString(), Mockito.anyString(), Mockito.any(), Mockito.any());
+        this.sweeper.sweep(shardId, "id", 2L, this.getTestJsonSource(), 1L, 1L);
+        Mockito.verify(this.scheduler, Mockito.times(0)).schedule(Mockito.anyString(), Mockito.anyString(),
+                Mockito.any(), Mockito.any(), Mockito.any(JobDocVersion.class));
 
         ScheduledJobParameter mockJobParameter = Mockito.mock(ScheduledJobParameter.class);
         Mockito.when(mockJobParameter.isEnabled()).thenReturn(true);
         Mockito.when(this.jobParser.parse(Mockito.any(), Mockito.anyString(), Mockito.anyLong())).thenReturn(mockJobParameter);
 
-        this.sweeper.sweep(shardId, "id", 2L, this.getTestJsonSource());
-        Mockito.verify(this.scheduler).schedule(Mockito.anyString(), Mockito.anyString(), Mockito.any(), Mockito.any());
+        this.sweeper.sweep(shardId, "id", 2L, this.getTestJsonSource(), 1L, 1L);
+        Mockito.verify(this.scheduler).schedule(Mockito.anyString(), Mockito.anyString(), Mockito.any(), Mockito.any(),
+                Mockito.any(JobDocVersion.class));
     }
 
     private ClusterState addNodesToCluter(ClusterState clusterState, int nodeCount) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeperTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeperTests.java
@@ -195,14 +195,14 @@ public class JobSweeperTests extends ESAllocationTestCase {
 
         Mockito.when(this.clusterService.state()).thenReturn(clusterState);
         JobSweeper testSweeper = Mockito.spy(this.sweeper);
-        Mockito.doNothing().when(testSweeper).sweep(Mockito.any(), Mockito.anyString(), Mockito.anyLong(), Mockito.any(),
-                Mockito.anyLong(), Mockito.anyLong());
+        Mockito.doNothing().when(testSweeper).sweep(Mockito.any(), Mockito.anyString(), Mockito.any(BytesReference.class),
+                Mockito.any(JobDocVersion.class));
         for (int i = 0; i<clusterState.getNodes().getSize(); i++) {
             testSweeper.postIndex(shardId, index, indexResult);
         }
 
-        Mockito.verify(testSweeper).sweep(Mockito.any(), Mockito.anyString(), Mockito.anyLong(), Mockito.any(),
-                Mockito.anyLong(), Mockito.anyLong());
+        Mockito.verify(testSweeper).sweep(Mockito.any(), Mockito.anyString(), Mockito.any(BytesReference.class),
+                Mockito.any(JobDocVersion.class));
     }
 
     @Test
@@ -246,7 +246,7 @@ public class JobSweeperTests extends ESAllocationTestCase {
     public void testSweep() throws IOException {
         ShardId shardId = new ShardId(new Index("index-name", IndexMetaData.INDEX_UUID_NA_VALUE), 1);
 
-        this.sweeper.sweep(shardId, "id", 2L, this.getTestJsonSource(), 1L, 1L);
+        this.sweeper.sweep(shardId, "id", this.getTestJsonSource(), new JobDocVersion(1L, 1L, 2L));
         Mockito.verify(this.scheduler, Mockito.times(0)).schedule(Mockito.anyString(), Mockito.anyString(),
                 Mockito.any(), Mockito.any(), Mockito.any(JobDocVersion.class));
 
@@ -254,7 +254,7 @@ public class JobSweeperTests extends ESAllocationTestCase {
         Mockito.when(mockJobParameter.isEnabled()).thenReturn(true);
         Mockito.when(this.jobParser.parse(Mockito.any(), Mockito.anyString(), Mockito.anyLong())).thenReturn(mockJobParameter);
 
-        this.sweeper.sweep(shardId, "id", 2L, this.getTestJsonSource(), 1L, 1L);
+        this.sweeper.sweep(shardId, "id", this.getTestJsonSource(), new JobDocVersion(1L, 1L, 2L));
         Mockito.verify(this.scheduler).schedule(Mockito.anyString(), Mockito.anyString(), Mockito.any(), Mockito.any(),
                 Mockito.any(JobDocVersion.class));
     }


### PR DESCRIPTION
*Issue #4 *

*Description of changes:* This change updates the JobScheduler plugin to build with Elasticsearch 7.0, and make the change to use document primary_term and seq_no for job versioning, which is a breaking change introduced in ES7.0.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
