### PR TITLE
Converts lock service to async

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ integTestCluster {
 
 allprojects {
     group = 'com.amazon.opendistroforelasticsearch'
-    version = "${opendistroVersion}.1"
+    version = "${opendistroVersion}.0"
 
     apply from: "$rootDir/build-tools/repositories.gradle"
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ integTestCluster {
 
 allprojects {
     group = 'com.amazon.opendistroforelasticsearch'
-    version = "${opendistroVersion}.0"
+    version = "${opendistroVersion}.1"
 
     apply from: "$rootDir/build-tools/repositories.gradle"
 

--- a/opendistro-elasticsearch-job-scheduler.release-notes
+++ b/opendistro-elasticsearch-job-scheduler.release-notes
@@ -29,12 +29,12 @@
 * Feature [#4](https://github.com/opendistro-for-elasticsearch/job-scheduler/issues/4) Add Support for Elasticsearch 7.0
 * Feature [#7](https://github.com/opendistro-for-elasticsearch/job-scheduler/issues/7) Singleton job execution using locking
 
-## 2019-06-27, version 0.10.0
+## 2019-06-27, version 0.10.0.0
 
 ### Notable Changes
 * Feature [PR #18](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/18) Add Support for Elasticsearch 6.8.1
 
-## 2019-04-10, version 0.9.0
+## 2019-04-10, version 0.9.0.0
 
 ### Notable Changes
 

--- a/opendistro-elasticsearch-job-scheduler.release-notes
+++ b/opendistro-elasticsearch-job-scheduler.release-notes
@@ -1,4 +1,9 @@
-## version 1.2.0 (Current)
+## version 1.3.0.0 (Current)
+
+### Breaking Changes
+* Converts LockService to asynchronous pattern to not block threadpool, this requires an update to usage as API changed.
+
+## 2019-06-25, version 1.2.0.0
 
 ### Notable Changes
 * Feature [PR #22](https://github.com/opendistro-for-elasticsearch/job-scheduler/issues/22) Add Support for Elasticsearch 7.2
@@ -6,7 +11,7 @@
 ### Bug fixes
 * [update ScheduledJobParser to use the JobDocVersion #15](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/15)
 
-## version 1.1.0
+## 2019-06-25, version 1.1.0.0
 
 ### Notable Changes
 * Feature [PR #16](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/16) Add Support for Elasticsearch 7.1
@@ -18,13 +23,18 @@
 * [Change log level when sweeper already have latest job version #11](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/11)
 * [Refactor JobSweeper to do sweep on certain clusterChangedEvent #10](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/10)
 
-## 2019-06-10, version 1.0.0
+## 2019-06-10, version 1.0.0.0
 
 ### Notable Changes
 * Feature [#4](https://github.com/opendistro-for-elasticsearch/job-scheduler/issues/4) Add Support for Elasticsearch 7.0
 * Feature [#7](https://github.com/opendistro-for-elasticsearch/job-scheduler/issues/7) Singleton job execution using locking
 
-## 2019-04-10
+## 2019-06-27, version 0.10.0
+
+### Notable Changes
+* Feature [PR #18](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/18) Add Support for Elasticsearch 6.8.1
+
+## 2019-04-10, version 0.9.0
 
 ### Notable Changes
 

--- a/spi/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/utils/LockServiceIT.java
+++ b/spi/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/utils/LockServiceIT.java
@@ -35,9 +35,9 @@ import com.amazon.opendistroforelasticsearch.jobscheduler.spi.JobExecutionContex
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.LockModel;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.ScheduledJobParameter;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.schedule.Schedule;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -45,8 +45,11 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes =1)
@@ -86,55 +89,118 @@ public class LockServiceIT extends ESIntegTestCase {
         }
     };
 
-    public void testSanity() {
+    public void testSanity() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), clusterService());
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
             lockService, JOB_INDEX_NAME, JOB_ID);
-
         Instant testTime = Instant.now();
         lockService.setTime(testTime);
-        LockModel lock = lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context);
-        assertNotNull("Expected to successfully grab lock.", lock);
-        assertEquals("job_id does not match.", JOB_ID, lock.getJobId());
-        assertEquals("job_index_name does not match.", JOB_INDEX_NAME, lock.getJobIndexName());
-        assertEquals("lock_id does not match.", LockModel.generateLockId(JOB_INDEX_NAME, JOB_ID), lock.getLockId());
-        assertEquals("lock_duration_seconds does not match.", LOCK_DURATION_SECONDS, lock.getLockDurationSeconds());
-        assertEquals("lock_time does not match.", testTime.getEpochSecond(), lock.getLockTime().getEpochSecond());
-        assertFalse("Lock should not be released.", lock.isReleased());
-        assertFalse("Lock should not expire.", lock.isExpired());
-        assertTrue("Failed to release lock.", lockService.release(lock));
-        assertTrue("Failed to delete lock.",lockService.deleteLock(lock.getLockId()));
+        lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                lock -> {
+                    assertNotNull("Expected to successfully grab lock.", lock);
+                    assertEquals("job_id does not match.", JOB_ID, lock.getJobId());
+                    assertEquals("job_index_name does not match.", JOB_INDEX_NAME, lock.getJobIndexName());
+                    assertEquals("lock_id does not match.", LockModel.generateLockId(JOB_INDEX_NAME, JOB_ID), lock.getLockId());
+                    assertEquals("lock_duration_seconds does not match.", LOCK_DURATION_SECONDS, lock.getLockDurationSeconds());
+                    assertEquals("lock_time does not match.", testTime.getEpochSecond(), lock.getLockTime().getEpochSecond());
+                    assertFalse("Lock should not be released.", lock.isReleased());
+                    assertFalse("Lock should not expire.", lock.isExpired());
+                    lockService.release(lock, ActionListener.wrap(
+                            released -> {
+                                assertTrue("Failed to release lock.", released);
+                                lockService.deleteLock(lock.getLockId(), ActionListener.wrap(
+                                        deleted -> {
+                                            assertTrue("Failed to delete lock.", deleted);
+                                            latch.countDown();
+                                        },
+                                        exception -> fail(exception.getMessage())
+                                ));
+                            },
+                            exception -> fail(exception.getMessage())
+                    ));
+                },
+                exception -> fail(exception.getMessage())
+        ));
+        latch.await(10000L, TimeUnit.MILLISECONDS);
     }
 
-    public void testSecondAcquireLockFail() {
+    public void testSecondAcquireLockFail() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), clusterService());
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
             lockService, JOB_INDEX_NAME, JOB_ID);
 
-        LockModel lock = lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context);
-        LockModel lock2 = lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context);
-        assertNotNull("Expected to successfully grab lock", lock);
-        assertNull("Expected to failed to get lock.", lock2);
-        assertTrue("Failed to release lock.", lockService.release(lock));
-        lockService.deleteLock(lock.getLockId());
-        assertTrue("Failed to delete lock.",lockService.deleteLock(lock.getLockId()));
+        lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                lock -> {
+                    assertNotNull("Expected to successfully grab lock", lock);
+                    lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                            lock2 -> {
+                                assertNull("Expected to failed to get lock.", lock2);
+                                lockService.release(lock, ActionListener.wrap(
+                                        released -> {
+                                            assertTrue("Failed to release lock.", released);
+                                            lockService.deleteLock(lock.getLockId(), ActionListener.wrap(
+                                                    deleted -> {
+                                                        assertTrue("Failed to delete lock.", deleted);
+                                                        latch.countDown();
+                                                    },
+                                                    exception -> fail(exception.getMessage())
+                                            ));
+                                        },
+                                        exception -> fail(exception.getMessage())
+                                ));
+                            },
+                            exception -> fail(exception.getMessage())
+                    ));
+                },
+                exception -> fail(exception.getMessage())
+        ));
+        latch.await(10000L, TimeUnit.MILLISECONDS);
     }
 
-    public void testLockReleasedAndAcquired() {
+    public void testLockReleasedAndAcquired() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), clusterService());
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
             lockService, JOB_INDEX_NAME, JOB_ID);
 
-        LockModel lock = lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context);
-        assertNotNull("Expected to successfully grab lock", lock);
-        assertTrue("Failed to release lock.", lockService.release(lock));
-        LockModel lock2 = lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context);
-        assertNotNull("Expected to successfully grab lock", lock2);
-        assertTrue("Failed to release lock.", lockService.release(lock2));
-        assertTrue("Failed to delete lock.",lockService.deleteLock(lock.getLockId()));
+        lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                lock -> {
+                    assertNotNull("Expected to successfully grab lock", lock);
+                    lockService.release(lock, ActionListener.wrap(
+                            released -> {
+                                assertTrue("Failed to release lock.", released);
+                                lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                                        lock2 -> {
+                                            assertNotNull("Expected to successfully grab lock2", lock2);
+                                            lockService.release(lock2, ActionListener.wrap(
+                                                    released2 -> {
+                                                        assertTrue("Failed to release lock2.", released2);
+                                                        lockService.deleteLock(lock2.getLockId(), ActionListener.wrap(
+                                                                deleted -> {
+                                                                    assertTrue("Failed to delete lock2.", deleted);
+                                                                    latch.countDown();
+                                                                },
+                                                                exception -> fail(exception.getMessage())
+                                                        ));
+                                                    },
+                                                    exception -> fail(exception.getMessage())
+                                            ));
+                                        },
+                                        exception -> fail(exception.getMessage())
+                                ));
+                            },
+                            exception -> fail(exception.getMessage())
+                    ));
+                },
+                exception -> fail(exception.getMessage())
+        ));
+        latch.await(10000L, TimeUnit.MILLISECONDS);
     }
 
-    public void testLockExpired() {
+    public void testLockExpired() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), clusterService());
         // Set lock time in the past.
         lockService.setTime(Instant.now().minus(Duration.ofSeconds(LOCK_DURATION_SECONDS + LOCK_DURATION_SECONDS)));
@@ -142,122 +208,224 @@ public class LockServiceIT extends ESIntegTestCase {
             lockService, JOB_INDEX_NAME, JOB_ID);
 
 
-        LockModel lock = lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context);
-        assertNotNull("Expected to successfully grab lock", lock);
-        // Set lock back to current time to make the lock expire.
-        lockService.setTime(null);
-        LockModel lock2 = lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context);
-        assertNotNull("Expected to successfully grab lock", lock2);
-        assertFalse("Expected to fail releasing lock.", lockService.release(lock));
-        assertTrue("Expecting to successfully release lock.", lockService.release(lock2));
-        assertTrue("Failed to delete lock.",lockService.deleteLock(lock.getLockId()));
+        lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                lock -> {
+                    assertNotNull("Expected to successfully grab lock", lock);
+                    // Set lock back to current time to make the lock expire.
+                    lockService.setTime(null);
+                    lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                            lock2 -> {
+                                assertNotNull("Expected to successfully grab lock", lock2);
+                                lockService.release(lock, ActionListener.wrap(
+                                        released -> {
+                                            assertFalse("Expected to fail releasing lock.", released);
+                                            lockService.release(lock2, ActionListener.wrap(
+                                                    released2 -> {
+                                                        assertTrue("Expecting to successfully release lock.", released2);
+                                                        lockService.deleteLock(lock.getLockId(), ActionListener.wrap(
+                                                                deleted -> {
+                                                                    assertTrue("Failed to delete lock.", deleted);
+                                                                    latch.countDown();
+                                                                },
+                                                                exception -> fail(exception.getMessage())
+                                                        ));
+                                                    },
+                                                    exception -> fail(exception.getMessage())
+                                            ));
+                                        },
+                                        exception -> fail(exception.getMessage())
+                                ));
+                            },
+                            exception -> fail(exception.getMessage())
+                    ));
+                },
+                exception -> fail(exception.getMessage())
+        ));
+        latch.await(10000L, TimeUnit.MILLISECONDS);
     }
 
-    public void testDeleteLockWithOutIndexCreation() {
+    public void testDeleteLockWithOutIndexCreation() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), clusterService());
-        assertTrue("Failed to delete lock.",lockService.deleteLock("NonExistingLockId"));
+        lockService.deleteLock("NonExistingLockId", ActionListener.wrap(
+                deleted -> {
+                    assertTrue("Failed to delete lock.", deleted);
+                    latch.countDown();
+                },
+                exception -> fail(exception.getMessage())
+        ));
+        latch.await(10000L, TimeUnit.MILLISECONDS);
     }
 
-    public void testDeleteNonExistingLock() {
+    public void testDeleteNonExistingLock() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
         LockService lockService = new LockService(client(), clusterService());
-        lockService.createLockIndex();
-        assertTrue("Failed to delete lock.",lockService.deleteLock("NonExistingLockId"));
+        lockService.createLockIndex(ActionListener.wrap(
+                created -> {
+                    if (created) {
+                        lockService.deleteLock("NonExistingLockId", ActionListener.wrap(
+                                deleted -> {
+                                    assertTrue("Failed to delete lock.", deleted);
+                                    latch.countDown();
+                                },
+                                exception -> fail(exception.getMessage())
+                        ));
+
+                    } else {
+                        fail("Failed to create lock index.");
+                    }
+                },
+                exception -> fail(exception.getMessage())
+        ));
+        latch.await(10000L, TimeUnit.MILLISECONDS);
     }
+
+    private volatile static AtomicInteger multiThreadCreateLockCounter = new AtomicInteger(0);
 
     public void testMultiThreadCreateLock() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
         final LockService lockService = new LockService(client(), clusterService());
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
             lockService, JOB_INDEX_NAME, JOB_ID);
 
-        lockService.createLockIndex();
-        ExecutorService executor = Executors.newFixedThreadPool(3);
-        final AtomicReference<LockModel> lockModelAtomicReference = new AtomicReference<>(null);
-        Callable<Integer> callable = () -> {
-            LockModel lock = lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context);
-            if (lock != null) {
-                lockModelAtomicReference.set(lock);
-                return 1;
-            }
-            return 0;
-        };
 
-        List<Callable<Integer>> callables = Arrays.asList(
-            callable,
-            callable,
-            callable
-        );
+        lockService.createLockIndex(ActionListener.wrap(
+                created -> {
+                    if (created) {
+                        ExecutorService executor = Executors.newFixedThreadPool(3);
+                        final AtomicReference<LockModel> lockModelAtomicReference = new AtomicReference<>(null);
+                        Callable<Boolean> callable = () -> {
+                            CountDownLatch callableLatch = new CountDownLatch(1);
+                            lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                                    lock -> {
+                                        if (lock != null) {
+                                            lockModelAtomicReference.set(lock);
+                                            multiThreadCreateLockCounter.getAndAdd(1);
+                                        }
+                                        callableLatch.countDown();
+                                    },
+                                    exception -> fail(exception.getMessage())
+                            ));
+                            callableLatch.await(10000L, TimeUnit.MILLISECONDS);
+                            return true;
+                        };
 
-        final int counter = executor.invokeAll(callables)
-            .stream()
-            .map(future -> {
-                try {
-                    return future.get();
-                } catch (Exception e) {
-                    throw new IllegalStateException(e);
-                }
-            })
-            .mapToInt(Integer::intValue)
-            .sum();
-        executor.shutdown();
+                        List<Callable<Boolean>> callables = Arrays.asList(
+                                callable,
+                                callable,
+                                callable
+                        );
 
-        assertEquals("There should be only one that grabs the lock.", 1, counter);
+                        executor.invokeAll(callables)
+                                .forEach(future -> {
+                                    try {
+                                        future.get();
+                                    } catch (Exception e) {
+                                        fail(e.getMessage());
+                                    }
+                                });
+                        executor.shutdown();
+                        executor.awaitTermination(10000L, TimeUnit.MILLISECONDS);
 
-        final LockModel lock = lockModelAtomicReference.get();
-        assertNotNull("Expected to successfully grab lock", lock);
-        assertTrue("Failed to release lock.", lockService.release(lock));
-        assertTrue("Failed to delete lock.",lockService.deleteLock(lock.getLockId()));
+                        assertEquals("There should be only one that grabs the lock.", 1, multiThreadCreateLockCounter.get());
+
+                        final LockModel lock = lockModelAtomicReference.get();
+                        assertNotNull("Expected to successfully grab lock", lock);
+                        lockService.release(lock, ActionListener.wrap(
+                                released -> {
+                                    assertTrue("Failed to release lock.", released);
+                                    lockService.deleteLock(lock.getLockId(), ActionListener.wrap(
+                                            deleted -> {
+                                                assertTrue("Failed to delete lock.", deleted);
+                                                latch.countDown();
+                                            },
+                                            exception -> fail(exception.getMessage())
+                                    ));
+                                },
+                                exception -> fail(exception.getMessage())
+                        ));
+                    } else {
+                        fail("Failed to create lock index.");
+                    }
+                },
+                exception -> fail(exception.getMessage())
+        ));
+        assertTrue("Test timed out - possibly leaked into other tests", latch.await(30000L, TimeUnit.MILLISECONDS));
     }
 
+    private volatile static AtomicInteger multiThreadAcquireLockCounter = new AtomicInteger(0);
+
     public void testMultiThreadAcquireLock() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
         final LockService lockService = new LockService(client(), clusterService());
         final JobExecutionContext context = new JobExecutionContext(Instant.now(), new JobDocVersion(0, 0, 0),
             lockService, JOB_INDEX_NAME, JOB_ID);
 
-        lockService.createLockIndex();
+        lockService.createLockIndex(ActionListener.wrap(
+                created -> {
+                    if (created) {
+                        // Set lock time in the past.
+                        lockService.setTime(Instant.now().minus(Duration.ofSeconds(LOCK_DURATION_SECONDS + LOCK_DURATION_SECONDS)));
+                        lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                                createdLock -> {
+                                    assertNotNull(createdLock);
+                                    // Set lock back to current time to make the lock expire.
+                                    lockService.setTime(null);
 
-        // Set lock time in the past.
-        lockService.setTime(Instant.now().minus(Duration.ofSeconds(LOCK_DURATION_SECONDS + LOCK_DURATION_SECONDS)));
-        LockModel createdLock = lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context);
-        assertNotNull(createdLock);
-        // Set lock back to current time to make the lock expire.
-        lockService.setTime(null);
+                                    ExecutorService executor = Executors.newFixedThreadPool(3);
+                                    final AtomicReference<LockModel> lockModelAtomicReference = new AtomicReference<>(null);
+                                    Callable<Boolean> callable = () -> {
+                                        CountDownLatch callableLatch = new CountDownLatch(1);
+                                        lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context, ActionListener.wrap(
+                                                lock -> {
+                                                    if (lock != null) {
+                                                        lockModelAtomicReference.set(lock);
+                                                        Integer test = multiThreadAcquireLockCounter.getAndAdd(1);
+                                                    }
+                                                    callableLatch.countDown();
+                                                },
+                                                exception -> fail(exception.getMessage())
+                                        ));
+                                        callableLatch.await(10000L, TimeUnit.MILLISECONDS);
+                                        return true;
+                                    };
 
-        ExecutorService executor = Executors.newFixedThreadPool(3);
-        final AtomicReference<LockModel> lockModelAtomicReference = new AtomicReference<>(null);
-        Callable<Integer> callable = () -> {
-            LockModel lock = lockService.acquireLock(TEST_SCHEDULED_JOB_PARAM, context);
-            if (lock != null) {
-                lockModelAtomicReference.set(lock);
-                return 1;
-            }
-            return 0;
-        };
+                                    List<Callable<Boolean>> callables = Arrays.asList(
+                                            callable,
+                                            callable,
+                                            callable
+                                    );
 
-        List<Callable<Integer>> callables = Arrays.asList(
-            callable,
-            callable,
-            callable
-        );
+                                    executor.invokeAll(callables);
+                                    executor.shutdown();
+                                    executor.awaitTermination(10000L, TimeUnit.MILLISECONDS);
 
-        final int counter = executor.invokeAll(callables)
-            .stream()
-            .map(future -> {
-                try {
-                    return future.get();
-                } catch (Exception e) {
-                    throw new IllegalStateException(e);
-                }
-            })
-            .mapToInt(Integer::intValue)
-            .sum();
+                                    assertEquals("There should be only one that grabs the lock.", 1, multiThreadAcquireLockCounter.get());
 
-        executor.shutdown();
-
-        assertEquals("There should be only one that grabs the lock.", 1, counter);
-
-        final LockModel lock = lockModelAtomicReference.get();
-        assertNotNull("Expected to successfully grab lock", lock);
-        assertTrue("Failed to release lock.", lockService.release(lock));
-        assertTrue("Failed to delete lock.",lockService.deleteLock(lock.getLockId()));
+                                    final LockModel lock = lockModelAtomicReference.get();
+                                    assertNotNull("Expected to successfully grab lock", lock);
+                                    lockService.release(lock, ActionListener.wrap(
+                                            released -> {
+                                                assertTrue("Failed to release lock.", released);
+                                                lockService.deleteLock(lock.getLockId(), ActionListener.wrap(
+                                                        deleted -> {
+                                                            assertTrue("Failed to delete lock.", deleted);
+                                                            latch.countDown();
+                                                        },
+                                                        exception -> fail(exception.getMessage())
+                                                ));
+                                            },
+                                            exception -> fail(exception.getMessage())
+                                    ));
+                                },
+                                exception -> fail(exception.getMessage())
+                        ));
+                    } else {
+                        fail("Failed to create lock index.");
+                    }
+                },
+                exception -> fail(exception.getMessage())
+        ));
+        assertTrue("Test timed out - possibly leaked into other tests", latch.await(30000L, TimeUnit.MILLISECONDS));
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/sweeper/JobSweeper.java
@@ -27,6 +27,7 @@ import com.amazon.opendistroforelasticsearch.jobscheduler.utils.VisibleForTestin
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -209,7 +210,10 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
         if (this.scheduler.getScheduledJobIds(shardId.getIndexName()).contains(delete.id())) {
             log.info("Descheduling job {} on index {}", delete.id(), shardId.getIndexName());
             this.scheduler.deschedule(shardId.getIndexName(), delete.id());
-            lockService.deleteLock(LockModel.generateLockId(shardId.getIndexName(), delete.id()));
+            lockService.deleteLock(LockModel.generateLockId(shardId.getIndexName(), delete.id()), ActionListener.wrap(
+                    deleted -> log.debug("Deleted lock: {}", deleted),
+                    exception -> log.debug("Failed to delete lock", exception)
+            ));
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Lock service was written in synchronous blocking fashion which was causing issues such as blocking the write threadpool in elasticsearch. This converts lock service to be asynchronous.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
