### PR TITLE
CI/CD for Job-Scheduler

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -2,6 +2,7 @@ name: Release Job-Scheduler Artefacts
 on:
   push:
     branches:
+      - master
       - opendistro-*
 
 jobs:
@@ -11,18 +12,18 @@ jobs:
         java: [12]
 
     name: Build and Release Job-Scheduler Plugin
-    runs-on: [ubuntu-16.04]
+    runs-on: macos-latest
 
     steps:
       - name: Checkout Job-Scheduler
         uses: actions/checkout@v1
       
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+      #- name: Configure AWS Credentials
+      #  uses: aws-actions/configure-aws-credentials@v1
+      #  with:
+      #    aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #    aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #    aws-region: us-east-1
               
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v1
@@ -37,6 +38,8 @@ jobs:
           rpm_artifact=`ls build/distributions/*.rpm`
           deb_artifact=`ls build/distributions/*.deb`
           
-          aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-job-scheduler/
-          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-job-scheduler/
-          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-job-scheduler/
+          echo $artifact $rpm_artifact $deb_artifact
+          
+          #aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-job-scheduler/
+          #aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-job-scheduler/
+          #aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-job-scheduler/

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,12 +1,11 @@
-name: Release Job-Scheduler Artefacts
+name: Release Job-Scheduler Artifacts
 on:
   push:
     branches:
-      - master
       - opendistro-*
 
 jobs:
-  build:
+  Release-Job-Scheduler-Artifacts:
     strategy:
       matrix:
         java: [12]

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -2,7 +2,6 @@ name: Release Job-Scheduler Artefacts
 on:
   push:
     branches:
-      - master
       - opendistro-*
 
 jobs:
@@ -17,6 +16,13 @@ jobs:
     steps:
       - name: Checkout Job-Scheduler
         uses: actions/checkout@v1
+      
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
               
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v1
@@ -31,7 +37,6 @@ jobs:
           rpm_artifact=`ls build/distributions/*.rpm`
           deb_artifact=`ls build/distributions/*.deb`
           
-          echo $artifact
-          echo $rpm_artifact
-          echo $deb_artifact
-          
+          aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-job-scheduler/
+          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-job-scheduler/
+          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-job-scheduler/

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,37 @@
+name: Release Job-Scheduler Artefacts
+on:
+  push:
+    branches:
+      - master
+      - opendistro-*
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [12]
+
+    name: Build and Release Job-Scheduler Plugin
+    runs-on: [ubuntu-16.04]
+
+    steps:
+      - name: Checkout Job-Scheduler
+        uses: actions/checkout@v1
+              
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      
+      - name: Run build
+        run: |
+          #!/bin/bash
+          ./gradlew build buildDeb buildRpm --console=plain -Dbuild.snapshot=false
+          artifact=`ls build/distributions/*.zip`
+          rpm_artifact=`ls build/distributions/*.rpm`
+          deb_artifact=`ls build/distributions/*.deb`
+          
+          echo $artifact
+          echo $rpm_artifact
+          echo $deb_artifact
+          

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -18,12 +18,12 @@ jobs:
       - name: Checkout Job-Scheduler
         uses: actions/checkout@v1
       
-      #- name: Configure AWS Credentials
-      #  uses: aws-actions/configure-aws-credentials@v1
-      #  with:
-      #    aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #    aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #    aws-region: us-east-1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
               
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v1
@@ -38,8 +38,6 @@ jobs:
           rpm_artifact=`ls build/distributions/*.rpm`
           deb_artifact=`ls build/distributions/*.deb`
           
-          echo $artifact $rpm_artifact $deb_artifact
-          
-          #aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-job-scheduler/
-          #aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-job-scheduler/
-          #aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-job-scheduler/
+          aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-job-scheduler/
+          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-job-scheduler/
+          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-job-scheduler/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ on:
       - opendistro-*
 
 jobs:
-  build:
+  Build-Job-Scheduler:
     strategy:
       matrix:
         java: [12]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,28 @@
+name: Build and Test Job-Scheduler
+on:
+  push:
+    branches:
+      - master
+      - opendistro-*
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [12]
+
+    name: Build and Test Job-Scheduler Plugin
+    runs-on: [ubuntu-16.04]
+
+    steps:
+      - name: Checkout Job-Scheduler
+        uses: actions/checkout@v1
+        
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      
+      - name: Run build
+        run: |
+          ./gradlew build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
         java: [12]
 
     name: Build and Test Job-Scheduler Plugin
-    runs-on: [ubuntu-16.04]
+    runs-on: macos-latest
 
     steps:
       - name: Checkout Job-Scheduler


### PR DESCRIPTION
###CI.yml

This job will trigger on every code checkin in master and opendistro branches which then will build the job-scheduler plugin.

###CD.yml
This job will trigger whenever a code checkin is made on an opendistro branch or a new opendistro branch is cut. It will build all the artifacts and then upload to respective S3 paths.

Assumption: the new opendistro branch is cut only when the plugin is ready to be released.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.