### PR TITLE
push SPI jar to maven fix in the workflow

### DIFF
--- a/.github/workflows/push-job-sched-jar.yml
+++ b/.github/workflows/push-job-sched-jar.yml
@@ -28,7 +28,7 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
         run: |
           cd ..
-          echo $JAVA_HOME
+          export JAVA13_HOME=$JAVA_HOME
           aws s3 cp s3://opendistro-docs/github-actions/pgp-public-key .
           aws s3 cp s3://opendistro-docs/github-actions/pgp-private-key .
           

--- a/.github/workflows/push-job-sched-jar.yml
+++ b/.github/workflows/push-job-sched-jar.yml
@@ -1,9 +1,8 @@
 name: Upload SPI Jar to Maven
 
 on:
-  push:
-    tags: 
-      - v*
+  repository_dispatch:
+    types: [maven]
 jobs:
   upload-job-scheduler-jar:
     runs-on: [ubuntu-16.04]
@@ -41,4 +40,4 @@ jobs:
           
           cd job-scheduler/spi
           
-          ../gradlew publishShadowPublicationToSonatype-stagingRepository -Dcompiler.java=13 -Dbuild.snapshot=false -Djavax.net.ssl.trustStore=/opt/hostedtoolcache/jdk/13.0.2/x64/lib/security/cacerts
+          ../gradlew publishShadowPublicationToSonatype-stagingRepository -Dcompiler.java=13 -Dbuild.snapshot=false -Djavax.net.ssl.trustStore=/opt/hostedtoolcache/jdk/13.0.3/x64/lib/security/cacerts

--- a/.github/workflows/push-job-sched-jar.yml
+++ b/.github/workflows/push-job-sched-jar.yml
@@ -14,12 +14,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
         
-      - name: Configure AWS CLI
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+      # - name: Configure AWS CLI
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: us-east-1
 
       - name: Setup Java
         uses: actions/setup-java@v1

--- a/.github/workflows/push-job-sched-jar.yml
+++ b/.github/workflows/push-job-sched-jar.yml
@@ -28,7 +28,7 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
         run: |
           cd ..
-          export JAVA13_HOME=$JAVA_HOME
+          echo $JAVA_HOME
           aws s3 cp s3://opendistro-docs/github-actions/pgp-public-key .
           aws s3 cp s3://opendistro-docs/github-actions/pgp-private-key .
           
@@ -40,4 +40,4 @@ jobs:
           
           cd job-scheduler/spi
           
-          ../gradlew publishShadowPublicationToSonatype-stagingRepository -Dcompiler.java=13 -Dbuild.snapshot=false -Djavax.net.ssl.trustStore=/opt/hostedtoolcache/jdk/13.0.3/x64/lib/security/cacerts
+          ../gradlew publishShadowPublicationToSonatype-stagingRepository -Dcompiler.java=13 -Dbuild.snapshot=false -Djavax.net.ssl.trustStore=$JAVA_HOME/lib/security/cacerts

--- a/.github/workflows/push-job-sched-jar.yml
+++ b/.github/workflows/push-job-sched-jar.yml
@@ -33,6 +33,7 @@ jobs:
           cd ..
           export JAVA13_HOME=$JAVA_HOME
           echo "java home is $JAVA_HOME"
+          echo $PATH
         #  aws s3 cp s3://opendistro-docs/github-actions/pgp-public-key .
         #  aws s3 cp s3://opendistro-docs/github-actions/pgp-private-key .
           

--- a/.github/workflows/push-job-sched-jar.yml
+++ b/.github/workflows/push-job-sched-jar.yml
@@ -1,9 +1,11 @@
 name: Upload SPI Jar to Maven
 
-on:
-  push:
-    tags: 
-      - v*
+on: 
+  repository_dispatch:
+    types: [java]
+  # push:
+  #   tags: 
+  #     - v*
 jobs:
   upload-job-scheduler-jar:
     runs-on: [ubuntu-16.04]
@@ -30,15 +32,16 @@ jobs:
         run: |
           cd ..
           export JAVA13_HOME=$JAVA_HOME
-          aws s3 cp s3://opendistro-docs/github-actions/pgp-public-key .
-          aws s3 cp s3://opendistro-docs/github-actions/pgp-private-key .
+          echo "java home is $JAVA_HOME"
+        #  aws s3 cp s3://opendistro-docs/github-actions/pgp-public-key .
+        #  aws s3 cp s3://opendistro-docs/github-actions/pgp-private-key .
           
-          gpg --import pgp-public-key
-          gpg --allow-secret-key-import --import pgp-private-key
+        #  gpg --import pgp-public-key
+        #  gpg --allow-secret-key-import --import pgp-private-key
 
-          mkdir /home/runner/.gradle
-          aws s3 cp s3://opendistro-docs/github-actions/gradle.properties /home/runner/.gradle/
+        #  mkdir /home/runner/.gradle
+        #  aws s3 cp s3://opendistro-docs/github-actions/gradle.properties /home/runner/.gradle/
           
-          cd job-scheduler/spi
+        #  cd job-scheduler/spi
           
-          ../gradlew publishShadowPublicationToSonatype-stagingRepository -Dcompiler.java=13 -Dbuild.snapshot=false -Djavax.net.ssl.trustStore=/opt/hostedtoolcache/jdk/13.0.2/x64/lib/security/cacerts
+        #  ../gradlew publishShadowPublicationToSonatype-stagingRepository -Dcompiler.java=13 -Dbuild.snapshot=false -Djavax.net.ssl.trustStore=/opt/hostedtoolcache/jdk/13.0.2/x64/lib/security/cacerts

--- a/.github/workflows/push-job-sched-jar.yml
+++ b/.github/workflows/push-job-sched-jar.yml
@@ -1,11 +1,9 @@
 name: Upload SPI Jar to Maven
 
-on: 
-  repository_dispatch:
-    types: [java]
-  # push:
-  #   tags: 
-  #     - v*
+on:
+  push:
+    tags: 
+      - v*
 jobs:
   upload-job-scheduler-jar:
     runs-on: [ubuntu-16.04]
@@ -14,12 +12,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
         
-      # - name: Configure AWS CLI
-      #   uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     aws-region: us-east-1
+      - name: Configure AWS CLI
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
       - name: Setup Java
         uses: actions/setup-java@v1
@@ -32,17 +30,15 @@ jobs:
         run: |
           cd ..
           export JAVA13_HOME=$JAVA_HOME
-          echo "java home is $JAVA_HOME"
-          echo $PATH
-        #  aws s3 cp s3://opendistro-docs/github-actions/pgp-public-key .
-        #  aws s3 cp s3://opendistro-docs/github-actions/pgp-private-key .
+          aws s3 cp s3://opendistro-docs/github-actions/pgp-public-key .
+          aws s3 cp s3://opendistro-docs/github-actions/pgp-private-key .
           
-        #  gpg --import pgp-public-key
-        #  gpg --allow-secret-key-import --import pgp-private-key
+          gpg --import pgp-public-key
+          gpg --allow-secret-key-import --import pgp-private-key
 
-        #  mkdir /home/runner/.gradle
-        #  aws s3 cp s3://opendistro-docs/github-actions/gradle.properties /home/runner/.gradle/
+          mkdir /home/runner/.gradle
+          aws s3 cp s3://opendistro-docs/github-actions/gradle.properties /home/runner/.gradle/
           
-        #  cd job-scheduler/spi
+          cd job-scheduler/spi
           
-        #  ../gradlew publishShadowPublicationToSonatype-stagingRepository -Dcompiler.java=13 -Dbuild.snapshot=false -Djavax.net.ssl.trustStore=/opt/hostedtoolcache/jdk/13.0.2/x64/lib/security/cacerts
+          ../gradlew publishShadowPublicationToSonatype-stagingRepository -Dcompiler.java=13 -Dbuild.snapshot=false -Djavax.net.ssl.trustStore=/opt/hostedtoolcache/jdk/13.0.2/x64/lib/security/cacerts

--- a/.github/workflows/push-job-sched-jar.yml
+++ b/.github/workflows/push-job-sched-jar.yml
@@ -1,8 +1,10 @@
 name: Upload SPI Jar to Maven
 
 on:
-  repository_dispatch:
-    types: [maven]
+  push:
+    tags: 
+      - v*
+      
 jobs:
   upload-job-scheduler-jar:
     runs-on: [ubuntu-16.04]


### PR DESCRIPTION
*Issue #, if available:* push-job-sched-jar.yml  [failure](https://github.com/opendistro-for-elasticsearch/job-scheduler/runs/647381991?check_suite_focus=true)

*Description of changes:* JAVA_HOME path was manually configured which caused issue as it changed in github actions. Replaced with $JAVA_HOME


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
