### PR TITLE
JAVA_HOME path corrected

### DIFF
--- a/.github/workflows/push-job-sched-jar.yml
+++ b/.github/workflows/push-job-sched-jar.yml
@@ -41,4 +41,4 @@ jobs:
           
           cd job-scheduler/spi
           
-          ../gradlew publishShadowPublicationToSonatype-stagingRepository -Dcompiler.java=13 -Dbuild.snapshot=false -Djavax.net.ssl.trustStore=/opt/hostedtoolcache/jdk/13.0.2/x64/lib/security/cacerts
+          ../gradlew publishShadowPublicationToSonatype-stagingRepository -Dcompiler.java=13 -Dbuild.snapshot=false -Djavax.net.ssl.trustStore=$JAVA_HOME/lib/security/cacerts


### PR DESCRIPTION
Issue #, if available: push-job-sched-jar.yml [failure](https://github.com/opendistro-for-elasticsearch/job-scheduler/runs/647381991?check_suite_focus=true)

Description of changes: JAVA_HOME path was manually configured which caused issue as it changed in github actions. Replaced with $JAVA_HOME

[Tested](https://github.com/gaiksaya/job-scheduler/runs/676393467?check_suite_focus=true)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
