### PR TITLE
Update JobSchedulerPlugin to conform with changes to ExtensiblePlugin interface in Elasticsearch 7.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
 
 buildscript {
     ext {
-        es_version = System.getProperty("es.version", "7.8.0")
+        es_version = System.getProperty("es.version", "7.9.0")
     }
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@
 #   permissions and limitations under the License.
 #
 
-version = 1.9.0
+version = 1.10.0

--- a/release-notes/opendistro-for-elasticsearch.job-scheduler.release-notes-1.10.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch.job-scheduler.release-notes-1.10.0.0.md
@@ -1,0 +1,4 @@
+## 2020-08-18, version 1.10.0.0
+
+### New Features
+* Adds support for Elasticsearch 7.9.0 - [PR #63](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/63)

--- a/release-notes/opendistro-for-elasticsearch.job-scheduler.release-notes-1.10.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch.job-scheduler.release-notes-1.10.0.0.md
@@ -3,4 +3,4 @@
 Supported Elasticsearch version 7.9.0
 
 ### Maintenance
-* Adds support for Elasticsearch 7.9.0 ([#67](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/67))
+* Update JobSchedulerPlugin to conform with changes to ExtensiblePlugin interface in Elasticsearch 7.9.0 ([#67](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/67))

--- a/release-notes/opendistro-for-elasticsearch.job-scheduler.release-notes-1.10.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch.job-scheduler.release-notes-1.10.0.0.md
@@ -1,4 +1,4 @@
 ## 2020-08-18, version 1.10.0.0
 
 ### New Features
-* Adds support for Elasticsearch 7.9.0 - [PR #63](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/63)
+* Adds support for Elasticsearch 7.9.0 - [PR #67](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/67)

--- a/release-notes/opendistro-for-elasticsearch.job-scheduler.release-notes-1.10.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch.job-scheduler.release-notes-1.10.0.0.md
@@ -1,4 +1,6 @@
-## 2020-08-18, version 1.10.0.0
+## 2020-08-18 Version 1.10.0.0
 
-### New Features
-* Adds support for Elasticsearch 7.9.0 - [PR #67](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/67)
+Supported Elasticsearch version 7.9.0
+
+### Maintenance
+* Adds support for Elasticsearch 7.9.0 ([#67](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/67))

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/JobSchedulerPlugin.java
@@ -53,7 +53,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -124,9 +123,9 @@ public class JobSchedulerPlugin extends Plugin implements ExtensiblePlugin {
     }
 
     @Override
-    public void reloadSPI(ClassLoader loader) {
+    public void loadExtensions(ExtensionLoader loader) {
 
-        for (JobSchedulerExtension extension : ServiceLoader.load(JobSchedulerExtension.class, loader)) {
+        for (JobSchedulerExtension extension : loader.loadExtensions(JobSchedulerExtension.class)) {
             String jobType = extension.getJobType();
             String jobIndexName = extension.getJobIndex();
             ScheduledJobParser jobParser = extension.getJobParser();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Bump Elasticsearch version to 7.9.0
- Change an overriding function in class `JobSchedulerPlugin` due to the change in the abstract class `ExtensiblePlugin` (https://github.com/elastic/elasticsearch/pull/58542)
- Bump ODFE version to 1.10.0 (due to the change above)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
