### PR TITLE
Fix download and doc links in package description

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,10 +119,10 @@ afterEvaluate {
 
         license 'ASL-2.0'
         maintainer 'OpenDistro for Elasticsearch Team <opendistro@amazon.com>'
-        url 'https://opendistro.github.io/elasticsearch/downloads'
+        url 'https://opendistro.github.io/for-elasticsearch/downloads.html'
         summary '''
          JobScheduler plugin for OpenDistro for Elasticsearch. 
-         Reference documentation can be found at https://opendistro.github.io/elasticsearch/docs.
+         Reference documentation can be found at https://opendistro.github.io/for-elasticsearch-docs/.
     '''.stripIndent().replace('\n', ' ').trim()
     }
 


### PR DESCRIPTION
*Issue #, if available:*
A community user found a bug in the links stated in package descriptions. check the post [here](https://discuss.opendistrocommunity.dev/t/unable-to-setup-apt-repo-for-opendistro-in-our-org/3124)

*Description of changes:*
Fix the download and document link in package description

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
