### PR TITLE
Add supports to Elasticsearch 7.9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
 
 buildscript {
     ext {
-        es_version = System.getProperty("es.version", "7.9.0")
+        es_version = System.getProperty("es.version", "7.9.1")
     }
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@
 #   permissions and limitations under the License.
 #
 
-version = 1.10.0
+version = 1.10.1

--- a/release-notes/opendistro-for-elasticsearch-job-scheduler.release-notes-1.10.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch-job-scheduler.release-notes-1.10.0.0.md
@@ -1,0 +1,6 @@
+## 2020-08-18 Version 1.10.0.0
+
+Compatible with Elasticsearch 7.9.0
+
+### Maintenance
+* Update JobSchedulerPlugin to conform with changes to ExtensiblePlugin interface in Elasticsearch 7.9.0 ([#67](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/67))

--- a/release-notes/opendistro-for-elasticsearch-job-scheduler.release-notes-1.10.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch-job-scheduler.release-notes-1.10.0.0.md
@@ -1,6 +1,0 @@
-## 2020-08-18 Version 1.10.0.0
-
-Compatible with Elasticsearch 7.9.0
-
-### Maintenance
-* Update JobSchedulerPlugin to conform with changes to ExtensiblePlugin interface in Elasticsearch 7.9.0 ([#67](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/67))

--- a/release-notes/opendistro-for-elasticsearch-job-scheduler.release-notes-1.10.1.0.md
+++ b/release-notes/opendistro-for-elasticsearch-job-scheduler.release-notes-1.10.1.0.md
@@ -1,0 +1,12 @@
+## 2020-09-04 Version 1.10.1.0
+
+Compatible with Elasticsearch 7.9.1
+
+### Infrastructure
+* Fix download and doc links in package description ([#70](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/70))
+
+### Documentation
+* Adds workflow to generate draft release notes and reformat old release notes ([#68](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/68))
+
+### Maintenance
+* Update JobSchedulerPlugin to conform with changes to ExtensiblePlugin interface in Elasticsearch 7.9.0 ([#67](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/67))

--- a/release-notes/opendistro-for-elasticsearch-job-scheduler.release-notes-1.10.1.0.md
+++ b/release-notes/opendistro-for-elasticsearch-job-scheduler.release-notes-1.10.1.0.md
@@ -1,4 +1,4 @@
-## 2020-09-04 Version 1.10.1.0
+## 2020-09-08 Version 1.10.1.0
 
 Compatible with Elasticsearch 7.9.1
 
@@ -6,7 +6,7 @@ Compatible with Elasticsearch 7.9.1
 * Fix download and doc links in package description ([#70](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/70))
 
 ### Documentation
-* Adds workflow to generate draft release notes and reformat old release notes ([#68](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/68))
+* Add workflow to generate draft release notes and reformat old release notes ([#68](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/68))
 
 ### Maintenance
-* Update JobSchedulerPlugin to conform with changes to ExtensiblePlugin interface in Elasticsearch 7.9.0 ([#67](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/67))
+* Add supports to Elasticsearch 7.9.1 ([#71](https://github.com/opendistro-for-elasticsearch/job-scheduler/pull/71))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update ES version to 7.9.1 to avoid memory leak in Lucene 8.6.0 (and 8.6.1)
- Bump ODFE version to 1.10.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
