### PR TITLE
Making Schedule interface Writeable 

### DIFF
--- a/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/CronSchedule.java
+++ b/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/CronSchedule.java
@@ -22,6 +22,8 @@ import com.cronutils.parser.CronParser;
 import com.cronutils.utils.VisibleForTesting;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -53,6 +55,13 @@ public class CronSchedule implements Schedule {
         this.expression = expression;
         this.timezone = timezone;
         this.executionTime = ExecutionTime.forCron(cronParser.parse(this.expression));
+        clock = Clock.system(timezone);
+    }
+
+    public CronSchedule(StreamInput input) throws IOException {
+        timezone = input.readZoneId();
+        expression = input.readString();
+        executionTime = ExecutionTime.forCron(cronParser.parse(expression));
         clock = Clock.system(timezone);
     }
 
@@ -158,5 +167,11 @@ public class CronSchedule implements Schedule {
     @Override
     public int hashCode() {
         return Objects.hash(timezone, expression);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeZoneId(timezone);
+        out.writeString(expression);
     }
 }

--- a/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/IntervalSchedule.java
+++ b/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/IntervalSchedule.java
@@ -19,6 +19,8 @@ import com.cronutils.utils.VisibleForTesting;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -70,6 +72,14 @@ public class IntervalSchedule implements Schedule {
         this.unit = unit;
         this.intervalInMillis = Duration.of(interval, this.unit).toMillis();
         this.clock = Clock.system(ZoneId.systemDefault());
+    }
+
+    public IntervalSchedule(StreamInput input) throws IOException {
+        startTime = input.readInstant();
+        interval = input.readInt();
+        unit = input.readEnum(ChronoUnit.class);
+        intervalInMillis = input.readLong();
+        clock = Clock.system(ZoneId.systemDefault());
     }
 
     @VisibleForTesting
@@ -166,5 +176,13 @@ public class IntervalSchedule implements Schedule {
     @Override
     public int hashCode() {
         return Objects.hash(startTime, interval, unit, intervalInMillis);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeInstant(startTime);
+        out.writeInt(interval);
+        out.writeEnum(unit);
+        out.writeLong(intervalInMillis);
     }
 }

--- a/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/IntervalSchedule.java
+++ b/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/IntervalSchedule.java
@@ -78,7 +78,7 @@ public class IntervalSchedule implements Schedule {
         startTime = input.readInstant();
         interval = input.readInt();
         unit = input.readEnum(ChronoUnit.class);
-        intervalInMillis = input.readLong();
+        intervalInMillis = Duration.of(interval, unit).toMillis();
         clock = Clock.system(ZoneId.systemDefault());
     }
 
@@ -183,6 +183,5 @@ public class IntervalSchedule implements Schedule {
         out.writeInstant(startTime);
         out.writeInt(interval);
         out.writeEnum(unit);
-        out.writeLong(intervalInMillis);
     }
 }

--- a/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/Schedule.java
+++ b/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/Schedule.java
@@ -16,12 +16,13 @@
 package com.amazon.opendistroforelasticsearch.jobscheduler.spi.schedule;
 
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 
 import java.time.Duration;
 import java.time.Instant;
 
-public interface Schedule extends ToXContentObject {
+public interface Schedule extends Writeable, ToXContentObject {
 
     /**
      * Gets next job execution time of give time parameter.

--- a/spi/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/CronScheduleTests.java
+++ b/spi/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/CronScheduleTests.java
@@ -17,6 +17,8 @@ package com.amazon.opendistroforelasticsearch.jobscheduler.spi.schedule;
 
 import com.cronutils.model.time.ExecutionTime;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
@@ -150,5 +152,13 @@ public class CronScheduleTests extends ESTestCase {
         Assert.assertEquals(cronScheduleOne, cronScheduleTwo);
         Assert.assertNotEquals(cronScheduleOne, cronScheduleThree);
         Assert.assertEquals(cronScheduleOne.hashCode(), cronScheduleTwo.hashCode());
+    }
+
+    public void testCronScheduleAsStream() throws Exception {
+        BytesStreamOutput out = new BytesStreamOutput();
+        cronSchedule.writeTo(out);
+        StreamInput input = out.bytes().streamInput();
+        CronSchedule newCronSchedule = new CronSchedule(input);
+        assertEquals(cronSchedule, newCronSchedule);
     }
 }

--- a/spi/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/IntervalScheduleTests.java
+++ b/spi/src/test/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/schedule/IntervalScheduleTests.java
@@ -16,6 +16,9 @@
 package com.amazon.opendistroforelasticsearch.jobscheduler.spi.schedule;
 
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
@@ -144,5 +147,13 @@ public class IntervalScheduleTests extends ESTestCase {
         Assert.assertEquals(intervalScheduleOne, intervalScheduleTwo);
         Assert.assertNotEquals(intervalScheduleOne, intervalScheduleThree);
         Assert.assertEquals(intervalScheduleOne.hashCode(), intervalScheduleTwo.hashCode());
+    }
+
+    public void testIntervalScheduleAsStream() throws Exception {
+        BytesStreamOutput out = new BytesStreamOutput();
+        intervalSchedule.writeTo(out);
+        StreamInput input = out.bytes().streamInput();
+        IntervalSchedule newIntervalSchedule = new IntervalSchedule(input);
+        assertEquals(intervalSchedule, newIntervalSchedule);
     }
 }


### PR DESCRIPTION
Making Schedule interface Writeable and relevant changes for CronScheduler and IntervalScheduler classes.

- This is needed for converting Anomaly Detection API's to integrate with RestActions (Which is needed for supporting FGAC for AD).

*Issue*
https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/195

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
