### PR TITLE
Support adding delay to scheduled jobs executions

### DIFF
--- a/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/ScheduledJobParameter.java
+++ b/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/ScheduledJobParameter.java
@@ -75,7 +75,11 @@ public interface ScheduledJobParameter extends ToXContentObject {
 
     /**
      * The job will be delayed for a fixed amount of time for every execution.
-     * It's a simple way for the job to catch out or order (delayed or late) events most of the time.
+     * It will be reset to 0 if a negative number is given.
+     *
+     * The delay will be evaluated before every execution of the job,
+     * if it exceeds the time interval between the first and the second execution after the evaluation time,
+     * it will be cut down to be the same with the time interval.
      *
      * @return the fixed delay in seconds before the scheduled job executes. Null if there is no fixed delay.
      */

--- a/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/ScheduledJobParameter.java
+++ b/spi/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/spi/ScheduledJobParameter.java
@@ -72,4 +72,14 @@ public interface ScheduledJobParameter extends ToXContentObject {
      * @return job execution jitter
      */
     default Double getJitter() {return null;}
+
+    /**
+     * The job will be delayed for a fixed amount of time for every execution.
+     * It's a simple way for the job to catch out or order (delayed or late) events most of the time.
+     *
+     * @return the fixed delay in seconds before the scheduled job executes. Null if there is no fixed delay.
+     */
+    default Long getDelaySeconds() {
+        return null;
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/scheduler/JobScheduler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jobscheduler/scheduler/JobScheduler.java
@@ -147,6 +147,8 @@ public class JobScheduler {
         }
         Duration duration = Duration.between(this.clock.instant(), nextExecutionTime);
 
+        jobInfo.setExpectedExecutionTime(nextExecutionTime);
+
         // Too many jobs start at the same time point will bring burst. Add random jitter delay to spread out load.
         // Example, if interval is 10 minutes, jitter is 0.6, next job run will be randomly delayed by 0 to 10*0.6 minutes.
         Instant secondExecutionTimeFromNow = jobParameter.getSchedule().getNextExecutionTime(nextExecutionTime);
@@ -164,7 +166,11 @@ public class JobScheduler {
             }
         }
 
-        jobInfo.setExpectedExecutionTime(nextExecutionTime);
+        // Add the defined delay to the job execution
+        if (jobParameter.getDelaySeconds() != null) {
+            log.info("Delay: {} seconds", jobParameter.getDelaySeconds());
+            duration = duration.plusSeconds(jobParameter.getDelaySeconds());
+        }
 
         Runnable runnable = () -> {
             if (jobInfo.isDescheduled()) {


### PR DESCRIPTION
*Issue #, if available:*
Lacks a solution for the job to catch late events.
Scheduled jobs may depend on some data or other jobs, which probably got delayed for some reason.
For example, a job is scheduled to execute at 2PM, and it needs on data from 1PM to 2PM. The job might be failed to run when some data is delayed for a while.

*Description of changes:*
Support adding delay, which is a fixed amount of time to scheduled jobs executions.

It's an optional parameter of the job, it allows user to give the job a consist delay for every execution.
It's a simple way for the job to catch out or order (delayed or late) events most of the time.

- Add getter method `getDelaySeconds()` in `ScheduledJobParameter` interface
- Process the delay when scheduling the job in `reschedule()` in `JobScheduler` class
- Add unit test for scheduling job with a delay to the execution

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
