### PR TITLE
Update release-workflow.yml

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -37,7 +37,7 @@ jobs:
           cp ./build/distributions/*.deb job-scheduler-artifacts_deb
           cp ./build/distributions/*.rpm job-scheduler-artifacts
           cp ./build/distributions/*.rpm job-scheduler-artifacts_rpm
-          echo ::set-env name=TAG_VERSION::${GITHUB_REF/refs\/tags\//}
+          echo "TAG_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
       # AWS authentication
       - name: Configure AWS Credentials


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Job scheduler upload failed because of set-env disabled
https://github.com/opendistro-for-elasticsearch/job-scheduler/runs/1415015741

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
