### PR TITLE
Get aggregate code coverage, add coverage upload in test workflow and add badges in README

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -26,6 +26,10 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
         run: ./gradlew build
+      - name: Uploads coverage
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Artifacts Plugin
         uses: actions/upload-artifact@v1
         if: always()

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -1,11 +1,14 @@
 name: Test and Build Workflow
-# This workflow is triggered on pull requests to master or a opendistro release branch
+# This workflow is triggered on pull requests and pushes to master or an opendistro release branch
 on:
   pull_request:
     branches:
       - master
       - opendistro-*
-
+  push:
+    branches:
+      - master
+      - opendistro-*
 jobs:
   build:
     strategy:
@@ -26,6 +29,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
         run: ./gradlew build
+      # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
       - name: Uploads coverage
         uses: codecov/codecov-action@v1
         with:
@@ -36,6 +40,7 @@ jobs:
         with:
           name: job-scheduler-plugin
           path: ./build
+      # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Upload Artifacts Sample Plugin
         uses: actions/upload-artifact@v1
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Test Workflow](https://github.com/opendistro-for-elasticsearch/job-scheduler/workflows/Test%20and%20Build%20Workflow/badge.svg)](https://github.com/opendistro-for-elasticsearch/job-scheduler/actions)
+[![codecov](https://codecov.io/gh/opendistro-for-elasticsearch/job-scheduler/branch/master/graph/badge.svg)](https://codecov.io/gh/opendistro-for-elasticsearch/job-scheduler)
+![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
+
+
 # Open Distro for Elasticsearch Job Scheduler
 
 Open Distro for Elasticsearch JobScheduler plugin provides a framework for Elasticsearch plugin

--- a/build-tools/merged-coverage.gradle
+++ b/build-tools/merged-coverage.gradle
@@ -1,0 +1,67 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+allprojects {
+    plugins.withId('jacoco') {
+        jacoco.toolVersion = '0.8.5'
+        // For some reason this dependency isn't getting setup automatically by the jacoco plugin
+        tasks.withType(JacocoReport) { 
+            dependsOn tasks.withType(Test)
+        }
+    }
+}
+
+task jacocoMerge(type: JacocoMerge) {
+    description = 'Gathers code coverage for all projects by merging the execution data files'
+
+    gradle.projectsEvaluated {
+        // collect code coverage of the sub-projects
+        subprojects.each {
+            jacocoMerge.dependsOn it.tasks.withType(JacocoReport)
+            jacocoMerge.executionData it.tasks.withType(JacocoReport).collect { it.executionData }
+        }
+        // collect code coverage of the root project
+        // analyze coverage for the root project before merging
+        jacocoMerge.dependsOn jacocoTestReport
+        // add the execution data file of the root project to be used during coverage analysis.
+        executionData jacocoTestReport.executionData
+    }
+    doFirst {
+        executionData = files(executionData.findAll { it.exists() })
+    }
+}
+
+task jacocoReport(type: JacocoReport, group: 'verification') {
+    description = 'Generates an aggregate report from all projects'
+    dependsOn jacocoMerge
+    executionData jacocoMerge.destinationFile
+
+    reports {
+        html.enabled = true // human readable
+        xml.enabled = true
+    }
+
+    gradle.projectsEvaluated {
+        // coverage data is being reported for all source dirs
+        getSourceDirectories().from(files(allprojects.sourceSets.main.allSource.srcDirs))
+        // coverage data is being reported for all class dirs except the classes for "sample-extension-plugin"
+        getClassDirectories().from(files(allprojects.sourceSets.main.output))
+        getClassDirectories().setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: '**/sampleextension/**')
+        }))
+    }
+}
+
+check.dependsOn jacocoReport

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
 
 buildscript {
     ext {
-        es_version = System.getProperty("es.version", "7.8.0")
+        es_version = System.getProperty("es.version", "7.10.2")
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
 
 buildscript {
     ext {
-        es_version = System.getProperty("es.version", "7.10.2")
+        es_version = System.getProperty("es.version", "7.8.0")
     }
 
     repositories {
@@ -30,6 +30,7 @@ buildscript {
 plugins {
     id 'nebula.ospackage' version "8.3.0"
     id 'java-library'
+    id 'jacoco'
 }
 
 ext {
@@ -40,6 +41,7 @@ ext {
 apply plugin: 'elasticsearch.esplugin'
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.java-rest-test'
+apply from: 'build-tools/merged-coverage.gradle'
 
 ext {
     projectSubstitutions = [:]

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -18,7 +18,6 @@ import org.elasticsearch.gradle.test.RestIntegTestTask
 plugins {
     id 'com.github.johnrengelman.shadow'
     id 'jacoco'
-    id 'maven'
     id 'maven-publish'
     id 'signing'
 }
@@ -32,20 +31,6 @@ ext {
     licenseFile = rootProject.file('LICENSE.txt')
     noticeFile = rootProject.file('NOTICE')
 }
-
-jacoco {
-    toolVersion = '0.8.5'
-    reportsDir = file("$buildDir/JacocoReport")
-}
-
-jacocoTestReport {
-    reports {
-        xml.enabled false
-        csv.enabled false
-        html.destination file("${buildDir}/jacoco/")
-    }
-}
-check.dependsOn jacocoTestReport
 
 dependencies {
     compileOnly "org.elasticsearch:elasticsearch:${es_version}"
@@ -150,4 +135,3 @@ signing {
     required { gradle.taskGraph.hasTask("publishShadowPublicationToSonatype-stagingRepository") }
     sign publishing.publications.shadow
 }
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Merge the code coverage of the root project and sub-project (Job Scheduler SPI) by utilizing the Gradle script in `alerting` repo: https://github.com/opendistro-for-elasticsearch/alerting/blob/master/build-tools/merged-coverage.gradle
- Use Codecov to visualize the code coverage result
- Add Coverage Report Upload action in test-and- build-workflow
- Add several badges in README
- Add codecov config file (TODO)

This PR carries the code coverage visualization that already in `index-management` and ‘alerting’ repo to `job-scheduler`
https://github.com/opendistro-for-elasticsearch/index-management/pull/230
https://github.com/opendistro-for-elasticsearch/index-management/pull/231
https://github.com/opendistro-for-elasticsearch/index-management/pull/232
https://github.com/opendistro-for-elasticsearch/index-management/pull/251
https://github.com/opendistro-for-elasticsearch/alerting/pull/223
https://github.com/opendistro-for-elasticsearch/alerting/pull/231

Concern: I think we should discuss which class is needed to do the code coverage analysis, and which don't.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
